### PR TITLE
Added response streaming

### DIFF
--- a/src/api/ollama-api.ts
+++ b/src/api/ollama-api.ts
@@ -1,4 +1,6 @@
+import { queryPostChatStream } from "./queries/post-chat-stream.query";
 import { queryPostChat } from "./queries/post-chat.query";
+import { queryPostGenerateStream } from "./queries/post-generate-stream.query";
 import { queryPostGenerate } from "./queries/post-generate.query";
 
 const BASE_URL: string = "http://localhost:11434";
@@ -7,5 +9,7 @@ export const OllamaAPI = {
 
     generate: queryPostGenerate(BASE_URL),
     chat: queryPostChat(BASE_URL),
+    generateStream: queryPostGenerateStream(BASE_URL),
+    chatStream: queryPostChatStream(BASE_URL)
 
 }

--- a/src/api/queries/post-chat-stream.query.ts
+++ b/src/api/queries/post-chat-stream.query.ts
@@ -1,38 +1,10 @@
 import { OllamaConversation } from "../../models/ollama-conversation.model";
-import { OllamaMessage } from "../../models/ollama-message.model";
 import { OllamaSupportedModel } from "../../models/ollama-supported-model.model";
 import { validatePrompt } from "../validators/query.validator";
+import { OllamaChatRequest, OllamaToolRequest } from "./post-chat.query";
 
-export type OllamaToolRequest = {
-    type: string;
-    function: {
-        name: string;
-        properties: unknown;
-    };
-};
-
-export type OllamaChatRequest = {
-    model: OllamaSupportedModel;
-    messages: OllamaMessage[];
-    tools?: OllamaToolRequest[];
-    stream?: boolean;
-}
-
-export type OllamaChatResponse = {
-    model: OllamaSupportedModel;
-    created_at: string;
-    message: OllamaMessage;
-    done: boolean;
-    total_duration: number;
-    load_duration: number;
-    prompt_eval_count: number;
-    prompt_eval_duration: number;
-    eval_count: number;
-    eval_duration: number;
-};
-
-export const queryPostChat = (baseUrl: string) => {
-    return async (model: OllamaSupportedModel, conversation: OllamaConversation, tools?: OllamaToolRequest[]): Promise<OllamaChatResponse> => {
+export const queryPostChatStream = (baseUrl: string) => {
+    return async (model: OllamaSupportedModel, conversation: OllamaConversation, tools?: OllamaToolRequest[]): Promise<Response> => {
         try {
             const latestMessage = conversation.latestMessage;
             if (latestMessage === null) {
@@ -48,7 +20,7 @@ export const queryPostChat = (baseUrl: string) => {
             }
         }
 
-        const response = await fetch(
+        const response = fetch(
             `${baseUrl}/api/chat`,
             {
                 method: "POST",
@@ -56,11 +28,11 @@ export const queryPostChat = (baseUrl: string) => {
                     model: model,
                     messages: conversation.messages,
                     tools: tools || [],
-                    stream: false
+                    stream: true
                 } as OllamaChatRequest)
             }
         );
 
-        return await response.json();
+        return response;
     }
 }

--- a/src/api/queries/post-generate-stream.query.ts
+++ b/src/api/queries/post-generate-stream.query.ts
@@ -23,22 +23,21 @@ export type OllamaGenerateResponse = {
     eval_duration: number;
 };
 
-export const queryPostGenerate = (baseUrl: string) => {
-    return async (model: OllamaSupportedModel, message: OllamaMessage): Promise<OllamaGenerateResponse> => {
+export const queryPostGenerateStream = (baseUrl: string) => {
+    return async (model: OllamaSupportedModel, message: OllamaMessage): Promise<Response> => {
         try {
             if (message === null) {
-                return Promise.reject(new Error("No messages in conversation"));
+                throw new Error("No messages in conversation");
             }
 
             validatePrompt(message.content);
         } catch (e: unknown) {
             if (e instanceof Error) {
-                throw Promise.reject(new Error(`Invalid prompt: ${e.message || 'Unknown error'}`));
+                throw new Error(`Invalid prompt: ${e.message || 'Unknown error'}`);
             } else {
-                throw Promise.reject(new Error('Invalid prompt: Unknown error'));
+                throw new Error('Invalid prompt: Unknown error');
             }
         }
-
 
         const response = await fetch(
             `${baseUrl}/api/generate`,
@@ -47,11 +46,11 @@ export const queryPostGenerate = (baseUrl: string) => {
                 body: JSON.stringify({
                     model: model,
                     prompt: message.content,
-                    stream: false
+                    stream: true
                 } as OllamaGenerateRequest)
             }
         );
 
-        return await response.json();
+        return response;
     }
 }

--- a/src/api/queries/post-generate.query.ts
+++ b/src/api/queries/post-generate.query.ts
@@ -24,21 +24,20 @@ export type OllamaGenerateResponse = {
 };
 
 export const queryPostGenerate = (baseUrl: string) => {
-    return async (model: OllamaSupportedModel, message: OllamaMessage): Promise<OllamaGenerateResponse> => {
+    return async (model: OllamaSupportedModel, message: OllamaMessage): Promise<Response> => {
         try {
             if (message === null) {
-                return Promise.reject(new Error("No messages in conversation"));
+                throw new Error("No messages in conversation");
             }
 
             validatePrompt(message.content);
         } catch (e: unknown) {
             if (e instanceof Error) {
-                throw Promise.reject(new Error(`Invalid prompt: ${e.message || 'Unknown error'}`));
+                throw new Error(`Invalid prompt: ${e.message || 'Unknown error'}`);
             } else {
-                throw Promise.reject(new Error('Invalid prompt: Unknown error'));
+                throw new Error('Invalid prompt: Unknown error');
             }
         }
-
 
         const response = await fetch(
             `${baseUrl}/api/generate`,
@@ -47,10 +46,11 @@ export const queryPostGenerate = (baseUrl: string) => {
                 body: JSON.stringify({
                     model: model,
                     prompt: message.content,
-                    stream: false
+                    stream: true
                 } as OllamaGenerateRequest)
             }
         );
-        return await response.json();
+
+        return response;
     }
 }

--- a/src/models/ollama-conversation.model.ts
+++ b/src/models/ollama-conversation.model.ts
@@ -32,4 +32,9 @@ export class OllamaConversation {
         this.revertToMessage(this.messages.length - 2);        
     }
 
+    public appendToLatestMessage(content: string): void {
+        if (this.messages.length === 0) return;
+        this.messages[this.messages.length - 1].content += content;
+    }
+
 }

--- a/src/pages/Query.tsx
+++ b/src/pages/Query.tsx
@@ -27,19 +27,18 @@ function QueryPage(): JSX.Element
       setQuestion('');
       setLoading(true);
 
-      OllamaAPI.generate(model, conversation.latestMessage)
+      OllamaAPI.generateStream(model, conversation.latestMessage)
         .then(async (response) => {
           conversation.addMessage(new OllamaMessage("", 'assistant'));
  
           const decoder = new TextDecoder("utf-8");
-          let iteration = 0;
           let thinkProcessed: boolean = false;
           const reader = response.body?.getReader();
           if (reader) {
             while (true) {
               const { done, value } = await reader.read();
               if (done) break;
-              console.info("Iteration: " + iteration++);
+
               const chunk = decoder.decode(value);
               try {
                 const chunkResponse: OllamaGenerateResponse = JSON.parse(chunk) as OllamaGenerateResponse;
@@ -51,7 +50,7 @@ function QueryPage(): JSX.Element
                 console.error(e);
               }
 
-              // Force refresh page if think tags have been closed
+              // Only render UI updates after the <think> tag is closed
               if(thinkProcessed) {
                 setConversation(new OllamaConversation(conversation.messages));
               }

--- a/src/pages/Query.tsx
+++ b/src/pages/Query.tsx
@@ -5,6 +5,7 @@ import { OllamaSupportedModel } from "../models/ollama-supported-model.model";
 import { OllamaConversation } from "../models/ollama-conversation.model";
 
 import Conversation from "../components/Conversation/Conversation";
+import { OllamaGenerateResponse } from "../api/queries/post-generate.query";
 
 
 function QueryPage(): JSX.Element
@@ -27,8 +28,35 @@ function QueryPage(): JSX.Element
       setLoading(true);
 
       OllamaAPI.generate(model, conversation.latestMessage)
-        .then((response) => {
-          conversation.addMessage(new OllamaMessage(response.response, 'assistant'));
+        .then(async (response) => {
+          conversation.addMessage(new OllamaMessage("", 'assistant'));
+ 
+          const decoder = new TextDecoder("utf-8");
+          let iteration = 0;
+          let thinkProcessed: boolean = false;
+          const reader = response.body?.getReader();
+          if (reader) {
+            while (true) {
+              const { done, value } = await reader.read();
+              if (done) break;
+              console.info("Iteration: " + iteration++);
+              const chunk = decoder.decode(value);
+              try {
+                const chunkResponse: OllamaGenerateResponse = JSON.parse(chunk) as OllamaGenerateResponse;
+                if (!thinkProcessed && chunkResponse.response.includes('</think>')) {
+                  thinkProcessed = true;
+                }
+                conversation.appendToLatestMessage(chunkResponse.response);
+              } catch (e) {
+                console.error(e);
+              }
+
+              // Force refresh page if think tags have been closed
+              if(thinkProcessed) {
+                setConversation(new OllamaConversation(conversation.messages));
+              }
+            }
+          }
 
           if (textareaRef.current) {
             textareaRef.current.focus();


### PR DESCRIPTION
Responses from the model are streamed to the client so they can see it populate in real time as it generates.

There is still a short delay because we need to wait for the full `<think>` tag to be returned before we can start streaming. This is because the think tag is always included at the start of the message and is always collapsed by default.

I've tried prompting the model to add the tag at the end of the message but it doesn't seem to listen - this solution will work for now.

I'll probably revisit this later and try to abstract the streaming code to a utility class so that code isn't duplicated across all uses but, again, it's fine for now.