### PR TITLE
Most recent model and conversation are kept in browser storage

### DIFF
--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -8,6 +8,7 @@ import Conversation, { ConversationEventType } from "../components/Conversation/
 import { OllamaChatResponse } from "../api/queries/post-chat.query";
 import { ResponseStreamer } from "../utils/response-streaming-util";
 import { useModelStorage } from "../utils/use-model-storage";
+import { useConversationStorage } from "../utils/use-conversation-storage";
 
 
 function ChatPage(): JSX.Element
@@ -15,7 +16,7 @@ function ChatPage(): JSX.Element
   const [question, setQuestion] = useState<string>('');
   const [loading, setLoading] = useState<boolean>(false);
   const [model, setModel] = useModelStorage();
-  const [conversation, setConversation] = useState<OllamaConversation>(new OllamaConversation());
+  const [conversation, setConversation] = useConversationStorage();
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   function onChangeModel(e: React.ChangeEvent<HTMLSelectElement>) {
@@ -29,6 +30,7 @@ function ChatPage(): JSX.Element
   function submitPrompt(prompt: string): void {
     const newMessage = new OllamaMessage(prompt);
     conversation.addMessage(newMessage);
+    setConversation(new OllamaConversation(conversation.messages));
 
     setQuestion('');
     setLoading(true);
@@ -36,6 +38,7 @@ function ChatPage(): JSX.Element
     OllamaAPI.chatStream(model, conversation)
       .then(async (response) => {
         conversation.addMessage(new OllamaMessage("", 'assistant'));
+        setConversation(new OllamaConversation(conversation.messages));
 
         let thinkProcessed: boolean = false;
         let hasSeenThinkTag: boolean = false;
@@ -77,6 +80,7 @@ function ChatPage(): JSX.Element
         alert(e.message);
         setQuestion(prompt);
         conversation.undoLatestMessage();
+        setConversation(new OllamaConversation(conversation.messages));
       })
 
       .finally(() => {

--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -7,13 +7,14 @@ import { OllamaMessage } from "../models/ollama-message.model";
 import Conversation, { ConversationEventType } from "../components/Conversation/Conversation";
 import { OllamaChatResponse } from "../api/queries/post-chat.query";
 import { ResponseStreamer } from "../utils/response-streaming-util";
+import { useModelStorage } from "../utils/use-model-storage";
 
 
 function ChatPage(): JSX.Element
 {
   const [question, setQuestion] = useState<string>('');
   const [loading, setLoading] = useState<boolean>(false);
-  const [model, setModel] = useState<OllamaSupportedModel>(OllamaSupportedModel.DeepseekR1);
+  const [model, setModel] = useModelStorage();
   const [conversation, setConversation] = useState<OllamaConversation>(new OllamaConversation());
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 

--- a/src/pages/Query.tsx
+++ b/src/pages/Query.tsx
@@ -7,13 +7,14 @@ import { OllamaConversation } from "../models/ollama-conversation.model";
 import Conversation from "../components/Conversation/Conversation";
 import { OllamaGenerateResponse } from "../api/queries/post-generate.query";
 import { ResponseStreamer } from "../utils/response-streaming-util";
+import { useModelStorage } from "../utils/use-model-storage";
 
 
 function QueryPage(): JSX.Element
 {
     const [question, setQuestion] = useState<string>('');
     const [loading, setLoading] = useState<boolean>(false);
-    const [model, setModel] = useState<OllamaSupportedModel>(OllamaSupportedModel.DeepseekR1);
+    const [model, setModel] = useModelStorage();
     const [conversation, setConversation] = useState<OllamaConversation>(new OllamaConversation());
     const textareaRef = useRef<HTMLTextAreaElement>(null);
   

--- a/src/utils/use-conversation-storage.ts
+++ b/src/utils/use-conversation-storage.ts
@@ -1,0 +1,45 @@
+import { useState, useEffect } from 'react';
+import { OllamaConversation } from '../models/ollama-conversation.model';
+import { OllamaMessage } from '../models/ollama-message.model';
+
+const STORAGE_KEY = 'ollama-latest-chat';
+
+export function useConversationStorage(): [OllamaConversation, (conversation: OllamaConversation) => void] {
+  // Initialize state with value from localStorage or empty conversation
+  const [conversation, setConversationState] = useState<OllamaConversation>(() => {
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY);
+      if (stored) {
+        const parsed = JSON.parse(stored) as { messages: OllamaMessage[] };
+        if (parsed && Array.isArray(parsed.messages)) {
+          return new OllamaConversation(parsed.messages);
+        }
+      }
+    } catch (error) {
+      console.warn('Failed to read conversation from localStorage:', error);
+    }
+    return new OllamaConversation();
+  });
+
+  // Save to localStorage whenever conversation changes
+  useEffect(() => {
+    try {
+      // Only save if there are messages
+      if (conversation.messages.length > 0) {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(conversation));
+      } else {
+        // Clear storage if conversation is empty
+        localStorage.removeItem(STORAGE_KEY);
+      }
+    } catch (error) {
+      console.warn('Failed to save conversation to localStorage:', error);
+    }
+  }, [conversation]);
+
+  // Wrapper function to update conversation
+  const setConversation = (newConversation: OllamaConversation) => {
+    setConversationState(newConversation);
+  };
+
+  return [conversation, setConversation];
+}

--- a/src/utils/use-model-storage.ts
+++ b/src/utils/use-model-storage.ts
@@ -1,0 +1,35 @@
+import { useState, useEffect } from 'react';
+import { OllamaSupportedModel } from '../models/ollama-supported-model.model';
+
+const STORAGE_KEY = 'ollama-active-model';
+
+export function useModelStorage(): [OllamaSupportedModel, (model: OllamaSupportedModel) => void] {
+  // Initialize state with value from localStorage or default
+  const [model, setModelState] = useState<OllamaSupportedModel>(() => {
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY);
+      if (stored && Object.values(OllamaSupportedModel).includes(stored as OllamaSupportedModel)) {
+        return stored as OllamaSupportedModel;
+      }
+    } catch (error) {
+      console.warn('Failed to read model from localStorage:', error);
+    }
+    return OllamaSupportedModel.DeepseekR1;
+  });
+
+  // Save to localStorage whenever model changes
+  useEffect(() => {
+    try {
+      localStorage.setItem(STORAGE_KEY, model);
+    } catch (error) {
+      console.warn('Failed to save model to localStorage:', error);
+    }
+  }, [model]);
+
+  // Wrapper function to update model
+  const setModel = (newModel: OllamaSupportedModel) => {
+    setModelState(newModel);
+  };
+
+  return [model, setModel];
+}


### PR DESCRIPTION
Deepseek, the default model, is slow on a steam deck so I wanted to use llama2-uncensored instead which is better-ish. I didn't want to change it every time a hot reload happened.

- Selected model is stored in local storage and persists through browser reloads
- Current conversation is stored in local storage and persists through browser reloads